### PR TITLE
Fixing iOS dimensions

### DIFF
--- a/lib/web2splash.js
+++ b/lib/web2splash.js
@@ -114,14 +114,18 @@ exports.images = [
     { name: 'bada-wac-type4-portrait.png', width: 480,  height: 800  },
     { name: 'bada-wac-type5-portrait.png', width: 240,  height: 400  },
     { name: 'blackberry-universal.png',    width: 225,  height: 225  },
+    // Not mentioned in guidelines here:
+    // http://developer.apple.com/library/ios/#documentation/userexperience/conceptual/mobilehig/IconsImages/IconsImages.html
     { name: 'ios-iphone-1x-landscape.png', width: 480,  height: 320  },
     { name: 'ios-iphone-1x-portrait.png',  width: 320,  height: 480  },
+    // Not mentioned in guidelines
     { name: 'ios-iphone-2x-landscape.png', width: 960,  height: 640  },
     { name: 'ios-iphone-2x-portrait.png',  width: 640,  height: 960  },
-    { name: 'ios-ipad-1x-landscape.png',   width: 1024, height: 783  },
+    { name: 'ios-ipad-1x-landscape.png',   width: 1024, height: 748  },
     { name: 'ios-ipad-1x-portrait.png',    width: 768,  height: 1004 },
-    { name: 'ios-ipad-2x-landscape.png',   width: 2008, height: 1536 },
+    { name: 'ios-ipad-2x-landscape.png',   width: 2048, height: 1496 },
     { name: 'ios-ipad-2x-portrait.png',    width: 1536, height: 2008 },
+    { name: 'ios-iphone5.png',             width: 640,  height: 1136 },
     { name: 'webos-universal.png',         width: 64,   height: 64   },
     { name: 'windows-phone-portrait.jpg',  width: 480,  height: 800  }
 ];


### PR DESCRIPTION
Fix for https://github.com/mwbrooks/web2splash/issues/1

I did not remove the extra iphone landscape screens in case they work. However, if they work their dimensions are probably off because they do not factor in the header bar.
