### PR TITLE
Add support to pixel ratio (eg. retina display)

### DIFF
--- a/lib/web2splash.js
+++ b/lib/web2splash.js
@@ -15,8 +15,8 @@ var async = require('./async');
  *         - `images` {Array} is an array of rendered images.
  *
  *             [
- *                 { name: 'android-ldpi-portrait.png', width: 240, height: 480 },
- *                 { name: 'android-mdpi-portrait.png', width: 480: height: 800 }
+ *                 { name: 'android-ldpi-portrait.png', width: 240, height: 480, pixelRatio:0.75 },
+ *                 { name: 'android-mdpi-portrait.png', width: 480, height: 800, pixelRatio:1.0  }
  *             ]
  */
 exports.render = function(input, output, callback) {
@@ -66,6 +66,17 @@ exports._renderImages = function(input, output, images, callback) {
                                 return callback(new Error('Could not open', input));
                             }
 
+                            /* Dealing with the pixel ratio */
+                            var pixelRatio = 1.0;
+                            
+                            if(typeof image.pixelRatio !== "undefined"){
+                                pixelRatio = image.pixelRatio
+                            }
+
+                            evaluate(page,function (pixelRatio) {
+                                document.body.style.zoom = pixelRatio;
+                            }, pixelRatio);
+
                             /* wait a bit then render the image */
                             setTimeout(function () {
                                 var filepath = path.join(output, image.name);
@@ -98,34 +109,50 @@ exports.onRenderImage = function(image) {
 };
 
 /*
+ * This function wraps WebPage.evaluate, and offers the possibility to pass
+ * parameters into the webpage function. The PhantomJS issue is here:
+ * 
+ *   http://code.google.com/p/phantomjs/issues/detail?id=132
+ * 
+ * This is from comment #43.
+ */
+
+function evaluate(page, func) {
+    var args = [].slice.call(arguments, 2);
+    var fn = "function() { return (" + func.toString() + ").apply(this, " + JSON.stringify(args) + ");}";
+    return page.evaluate(fn);
+}
+
+
+/*
  * The splash screens to render as images.
  */
-exports.images = [
-    { name: 'android-ldpi-landscape.png',  width: 320,  height: 200  },
-    { name: 'android-ldpi-portrait.png',   width: 200,  height: 320  },
-    { name: 'android-mdpi-landscape.png',  width: 480,  height: 320  },
-    { name: 'android-mdpi-portrait.png',   width: 320,  height: 480  },
-    { name: 'android-hdpi-landscape.png',  width: 800,  height: 480  },
-    { name: 'android-hdpi-portrait.png',   width: 480,  height: 800  },
-    { name: 'android-xhdpi-landscape.png', width: 1280, height: 720  },
-    { name: 'android-xhdpi-portrait.png',  width: 720,  height: 1280 },
-    { name: 'bada-portrait.png',           width: 480,  height: 800  },
-    { name: 'bada-wac-type3-portrait.png', width: 320,  height: 480  },
-    { name: 'bada-wac-type4-portrait.png', width: 480,  height: 800  },
-    { name: 'bada-wac-type5-portrait.png', width: 240,  height: 400  },
-    { name: 'blackberry-universal.png',    width: 225,  height: 225  },
+ exports.images = [
+    { name: 'android-ldpi-landscape.png',  width: 320,  height: 200,  pixelRatio:0.75 },
+    { name: 'android-ldpi-portrait.png',   width: 200,  height: 320,  pixelRatio:0.75 },
+    { name: 'android-mdpi-landscape.png',  width: 480,  height: 320,  pixelRatio:1.0  },
+    { name: 'android-mdpi-portrait.png',   width: 320,  height: 480,  pixelRatio:1.0  },
+    { name: 'android-hdpi-landscape.png',  width: 800,  height: 480,  pixelRatio:1.5  },
+    { name: 'android-hdpi-portrait.png',   width: 480,  height: 800,  pixelRatio:1.5  },
+    { name: 'android-xhdpi-landscape.png', width: 1280, height: 720,  pixelRatio:2.0  },
+    { name: 'android-xhdpi-portrait.png',  width: 720,  height: 1280, pixelRatio:2.0  },
+    { name: 'bada-portrait.png',           width: 480,  height: 800,  pixelRatio:1.0  },
+    { name: 'bada-wac-type3-portrait.png', width: 320,  height: 480,  pixelRatio:1.0  },
+    { name: 'bada-wac-type4-portrait.png', width: 480,  height: 800,  pixelRatio:1.0  },
+    { name: 'bada-wac-type5-portrait.png', width: 240,  height: 400,  pixelRatio:1.0  },
+    { name: 'blackberry-universal.png',    width: 225,  height: 225,  pixelRatio:1.0  },
     // Not mentioned in guidelines here:
     // http://developer.apple.com/library/ios/#documentation/userexperience/conceptual/mobilehig/IconsImages/IconsImages.html
-    { name: 'ios-iphone-1x-landscape.png', width: 480,  height: 320  },
-    { name: 'ios-iphone-1x-portrait.png',  width: 320,  height: 480  },
+    { name: 'ios-iphone-1x-landscape.png', width: 480,  height: 320,  pixelRatio:1.0  },
+    { name: 'ios-iphone-1x-portrait.png',  width: 320,  height: 480,  pixelRatio:1.0  },
     // Not mentioned in guidelines
-    { name: 'ios-iphone-2x-landscape.png', width: 960,  height: 640  },
-    { name: 'ios-iphone-2x-portrait.png',  width: 640,  height: 960  },
-    { name: 'ios-ipad-1x-landscape.png',   width: 1024, height: 748  },
-    { name: 'ios-ipad-1x-portrait.png',    width: 768,  height: 1004 },
-    { name: 'ios-ipad-2x-landscape.png',   width: 2048, height: 1496 },
-    { name: 'ios-ipad-2x-portrait.png',    width: 1536, height: 2008 },
-    { name: 'ios-iphone5.png',             width: 640,  height: 1136 },
-    { name: 'webos-universal.png',         width: 64,   height: 64   },
-    { name: 'windows-phone-portrait.jpg',  width: 480,  height: 800  }
+    { name: 'ios-iphone-2x-landscape.png', width: 960,  height: 640,  pixelRatio:2.0  },
+    { name: 'ios-iphone-2x-portrait.png',  width: 640,  height: 960,  pixelRatio:2.0  },
+    { name: 'ios-ipad-1x-landscape.png',   width: 1024, height: 748,  pixelRatio:1.0  },
+    { name: 'ios-ipad-1x-portrait.png',    width: 768,  height: 1004, pixelRatio:1.0  },
+    { name: 'ios-ipad-2x-landscape.png',   width: 2048, height: 1496, pixelRatio:2.0  },
+    { name: 'ios-ipad-2x-portrait.png',    width: 1536, height: 2008, pixelRatio:2.0  },
+    { name: 'ios-iphone5.png',             width: 640,  height: 1136, pixelRatio:2.0  },
+    { name: 'webos-universal.png',         width: 64,   height: 64,   pixelRatio:1.0  },
+    { name: 'windows-phone-portrait.jpg',  width: 480,  height: 800,  pixelRatio:1.0  }
 ];


### PR DESCRIPTION
Uses body.style.zoom to simulate the results when pixel density is different from 1.0. The
default screen styles were also updated to account for this change by
adding a new property: pixelRatio. Note that old exports still work as
before.
