### PR TITLE
Calling phantom.exit causes the process to exit.

### DIFF
--- a/lib/web2splash.js
+++ b/lib/web2splash.js
@@ -90,9 +90,7 @@ exports._renderImages = function(input, output, images, callback) {
                 },
                 /* After looping over all of the images, return with `callback(...)`. */
                 function(e) {
-                    phantom.exit(function() {
-                        return callback(null, images);
-                    });
+                    return callback(e, images);
                 }
             );
         });


### PR DESCRIPTION
Calling phantom.exit causes the process to exit, so using web2splash within another script or application doesn't work properly. I'm not sure the implications of not calling phantom.exit, but I need this in order for my build script to work.  FYI.

Love this idea, btw. Good work.
