### PR TITLE
Progressive quality digression to meet max_size requirements.

### DIFF
--- a/lib/web2splash.js
+++ b/lib/web2splash.js
@@ -61,7 +61,7 @@ exports._renderImages = function(input, output, images, callback) {
                 function(image, next) {
                     /* set viewport */
                     page.set('viewportSize', { width:image.width, height:image.height }, function(e) {
-                        console.warn(e);
+                        if (e) console.log('e',e);
                         /* open page */
                         page.open(input, function(status) {
                             if (status !== 'success') {
@@ -85,9 +85,11 @@ exports._renderImages = function(input, output, images, callback) {
                                 setTimeout(function () {
                                     var filepath = path.join(output, image.name);
                                     page.render(filepath,{quality:quality},function(e) {
-                                        if (e) console.warn(e);
+                                        if (e) console.log('e 2',e);
                                         // Check file size and append to image hash.
                                         fs.stat(filepath,function(err,stat){
+                                            if (err) console.log('err',e);
+
                                             image.size = stat.size;
                                             image.quality = quality;
                                             // If max_size option is set, check it and try again at a lower quality.

--- a/lib/web2splash.js
+++ b/lib/web2splash.js
@@ -1,5 +1,6 @@
 var path = require('path');
 var async = require('./async');
+var fs = require('fs');
 
 /*
  * render(input, output, [callback)]
@@ -77,14 +78,34 @@ exports._renderImages = function(input, output, images, callback) {
                                 document.body.style.zoom = pixelRatio;
                             }, pixelRatio);
 
-                            /* wait a bit then render the image */
-                            setTimeout(function () {
-                                var filepath = path.join(output, image.name);
-                                page.render(filepath, function() {
-                                    exports.onRenderImage(image);
-                                    next();
-                                });
-                            }, 200);
+                            /* Attempt first render at 100% quality */
+                            (function attemptRender(quality){
+                                /* wait a bit then render the image */
+                                setTimeout(function () {
+                                    var filepath = path.join(output, image.name);
+                                    page.render(filepath,{quality:quality},function() {
+                                        // Check file size and append to image hash.
+                                        fs.stat(filepath,function(err,stat){
+                                            image.size = stat.size;
+                                            image.quality = quality;
+                                            // If max_size option is set, check it and try again at a lower quality.
+                                            if (exports.max_size && exports.max_size < stat.size) {
+                                                if (quality > exports.min_quality)
+                                                    attemptRender(quality-exports.quality_increment);
+                                                else {
+                                                    image.warn = 'Could not render image under the max_size setting ('+exports.max_size+') without going under the min_quality setting ('+exports.min_quality+').';
+                                                    exports.onRenderImage(image);
+                                                    next();
+                                                }
+                                            } else {
+                                                exports.onRenderImage(image);
+                                                next();
+                                            }
+                                        });
+                                    });
+                                }, exports.render_timeout);
+                            })(100);
+
                         });
                     });
                 },
@@ -121,7 +142,10 @@ function evaluate(page, func) {
     return page.evaluate(fn);
 }
 
-
+exports.max_size;
+exports.min_quality = 50;
+exports.quality_increment = 5;
+exports.render_timeout = 200;
 /*
  * The splash screens to render as images.
  */

--- a/lib/web2splash.js
+++ b/lib/web2splash.js
@@ -115,7 +115,7 @@ exports._renderImages = function(input, output, images, callback) {
                 },
                 /* After looping over all of the images, return with `callback(...)`. */
                 function(e) {
-                    console.log('web2splash is ALL DONE!');
+                    console.log('web2splash is ALL DONE!',e);
                     return callback(e, images);
                 }
             );

--- a/lib/web2splash.js
+++ b/lib/web2splash.js
@@ -61,7 +61,6 @@ exports._renderImages = function(input, output, images, callback) {
                 function(image, next) {
                     /* set viewport */
                     page.set('viewportSize', { width:image.width, height:image.height }, function(e) {
-                        if (e) console.log('e',e);
                         /* open page */
                         page.open(input, function(status) {
                             if (status !== 'success') {
@@ -85,11 +84,8 @@ exports._renderImages = function(input, output, images, callback) {
                                 setTimeout(function () {
                                     var filepath = path.join(output, image.name);
                                     page.render(filepath,{quality:quality},function(e) {
-                                        if (e) console.log('e 2',e);
                                         // Check file size and append to image hash.
                                         fs.stat(filepath,function(err,stat){
-                                            if (err) console.log('err',e);
-
                                             image.size = stat.size;
                                             image.quality = quality;
                                             // If max_size option is set, check it and try again at a lower quality.
@@ -115,7 +111,6 @@ exports._renderImages = function(input, output, images, callback) {
                 },
                 /* After looping over all of the images, return with `callback(...)`. */
                 function(e) {
-                    console.log('web2splash is ALL DONE!',e);
                     return callback(e, images);
                 }
             );

--- a/lib/web2splash.js
+++ b/lib/web2splash.js
@@ -61,6 +61,7 @@ exports._renderImages = function(input, output, images, callback) {
                 function(image, next) {
                     /* set viewport */
                     page.set('viewportSize', { width:image.width, height:image.height }, function(e) {
+                        console.warn(e);
                         /* open page */
                         page.open(input, function(status) {
                             if (status !== 'success') {
@@ -83,7 +84,8 @@ exports._renderImages = function(input, output, images, callback) {
                                 /* wait a bit then render the image */
                                 setTimeout(function () {
                                     var filepath = path.join(output, image.name);
-                                    page.render(filepath,{quality:quality},function() {
+                                    page.render(filepath,{quality:quality},function(e) {
+                                        if (e) console.warn(e);
                                         // Check file size and append to image hash.
                                         fs.stat(filepath,function(err,stat){
                                             image.size = stat.size;
@@ -111,6 +113,7 @@ exports._renderImages = function(input, output, images, callback) {
                 },
                 /* After looping over all of the images, return with `callback(...)`. */
                 function(e) {
+                    console.log('web2splash is ALL DONE!');
                     return callback(e, images);
                 }
             );


### PR DESCRIPTION
Ok, this one may be off the rails.  But I'm encountering size issues with some of my splash screens, so I thought it would be nice to have some flexibility in setting the 'quality' property during the render process.

This change adds the following properties:

max_size - this value, in bytes, tells web2splash the max file size goal.  It does NOT prevent the output of a splash image if the size cannot be attained, but a warning message is attached to the image output in the onRenderImage function.

min_quality - this allows you to specify that you don't want your PNG to drop below a certain quality, even if the max_size cannot be attained.

quality_increment - this integer is used in decrementing the quality setting on a retry. Default is 5.

In short, web2splash would first attempt a render at 100% quality.  If the file size is below max_size, great.  If not, the quality would be decremented by the quality_increment amount (default 5) and the render would retry. Once the max_size value is reached, it moves on.  If it can't be reached, then a 'warn' value is added to the image hash the is sent to the onRenderImage function.  Something like this:

``` javascript
{
 name: 'ios-ipad-2x-portrait.png',
  width: 1536,
  height: 2008,
  pixelRatio: 2,
  size: 9646890,
  quality: 50,
  warn: 'Could not render image under the max_size setting (2048000) without going under the min_quality setting (50).' 
}
```
